### PR TITLE
Fix code scanning alert #45: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/unexelf.c
+++ b/src/unexelf.c
@@ -1329,6 +1329,6 @@ temacs:
   mask = umask (777);
   umask (mask);
   stat_buf.st_mode |= 0111 & ~mask;
-  if (chmod (new_name, stat_buf.st_mode) != 0)
-    fatal ("Can't chmod (%s): %s", new_name, strerror (errno));
+  if (fchmod (new_file, stat_buf.st_mode) != 0)
+    fatal ("Can't fchmod (%s): %s", new_name, strerror (errno));
 }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/45](https://github.com/cooljeanius/emacs/security/code-scanning/45)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
