### PR TITLE
Fix code scanning alert #70: Wrong type of arguments to formatting function

### DIFF
--- a/src/vmsgmalloc.c
+++ b/src/vmsgmalloc.c
@@ -1863,7 +1863,7 @@ tr_morecore (increment)
   p = (__ptr_t) (*__morecore) (increment);
   __morecore = tr_morecore;
 
-  fprintf (mallstream, "$ %p %d\n", p, increment);
+  fprintf (mallstream, "$ %p %ld\n", p, increment);
 
   return p;
 }
@@ -1880,7 +1880,7 @@ tr_lesscore (ptr, increment)
   p = (__ptr_t) (*__lesscore) (ptr, increment);
   __lesscore = tr_lesscore;
 
-  fprintf (mallstream, "* %p (%p, %d)\n", p, ptr, increment);
+  fprintf (mallstream, "* %p (%p, %ld)\n", p, ptr, increment);
 
   return p;
 }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/70](https://github.com/cooljeanius/emacs/security/code-scanning/70)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
