### PR TITLE
Fix code scanning alert #64: Wrong type of arguments to formatting function

### DIFF
--- a/src/unexcw.c
+++ b/src/unexcw.c
@@ -158,7 +158,7 @@ fixup_executable (int fd)
 	  assert (ret == my_edata - (char *) start_address);
 	  ++found_data;
 	  if (debug_unexcw)
-	    printf ("         .data, mem start %#lx mem length %d\n",
+	    printf ("         .data, mem start %#lx mem length %ld\n",
 		    start_address, my_edata - (char *) start_address);
 	  if (debug_unexcw)
 	    printf ("         .data, file start %d file length %d\n",


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/64](https://github.com/cooljeanius/emacs/security/code-scanning/64)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
