### PR TITLE
Fix code scanning alert no. 43: Multiplication result converted to larger type

### DIFF
--- a/src/xselect.c
+++ b/src/xselect.c
@@ -705,7 +705,7 @@ x_reply_selection_request (struct input_event *event,
 	    XChangeProperty (display, window, cs->property,
 			     cs->type, cs->format, PropModeAppend,
 			     cs->data, i);
-	    bytes_remaining -= i * format_bytes;
+	    bytes_remaining -= (long)i * format_bytes;
 	    cs->data += i * ((cs->format == 32) ? sizeof (long)
 			     : format_bytes);
 	    XFlush (display);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/43](https://github.com/cooljeanius/emacs/security/code-scanning/43)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to the larger type before performing the multiplication. In this case, we will cast `i` to `long` before multiplying it by `format_bytes`.

- **General fix:** Cast one of the operands to the larger type before performing the multiplication.
- **Detailed fix:** In the file `src/xselect.c`, on line 708, cast `i` to `long` before multiplying it by `format_bytes`.
- **Specific changes:** Modify the line `bytes_remaining -= i * format_bytes;` to `bytes_remaining -= (long)i * format_bytes;`.
- **Requirements:** No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
