### PR TITLE
Fix code scanning alert no. 40: Multiplication result converted to larger type

### DIFF
--- a/src/unexelf.c
+++ b/src/unexelf.c
@@ -826,7 +826,7 @@ unexec (const char *new_name, const char *old_name)
 
   memcpy (new_file_h, old_file_h, old_file_h->e_ehsize);
   memcpy (new_program_h, old_program_h,
-	  old_file_h->e_phnum * old_file_h->e_phentsize);
+	  (size_t)old_file_h->e_phnum * old_file_h->e_phentsize);
 
   /* Modify the e_shstrndx if necessary. */
   PATCH_INDEX (new_file_h->e_shstrndx);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/40](https://github.com/cooljeanius/emacs/security/code-scanning/40)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly assigned to the `size_t` variable.

The specific change involves casting `old_file_h->e_phnum` to `size_t` before multiplying it by `old_file_h->e_phentsize`. This change should be made on line 829 of the file `src/unexelf.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
