### PR TITLE
Fix code scanning alert no. 71: Multiplication result converted to larger type

### DIFF
--- a/src/unexsni.c
+++ b/src/unexsni.c
@@ -602,7 +602,7 @@ unexec (new_name, old_name, data_start, bss_start, entry_address)
 
   memcpy (new_file_h, old_file_h, old_file_h->e_ehsize);
   memcpy (new_program_h, old_program_h,
-	  old_file_h->e_phnum * old_file_h->e_phentsize);
+	  (size_t)old_file_h->e_phnum * old_file_h->e_phentsize);
 
   /* Modify the e_shstrndx if necessary. */
   PATCH_INDEX (new_file_h->e_shstrndx);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/71](https://github.com/cooljeanius/emacs/security/code-scanning/71)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly represented.

The specific change involves casting `old_file_h->e_phnum` to `size_t` before the multiplication on line 605.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
