### PR TITLE
Fix code scanning alert no. 75: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/unexec.c
+++ b/src/unexec.c
@@ -1130,17 +1130,26 @@ mark_x (name)
 {
   struct stat sbuf;
   int um;
+  int fd;
   int new = 0;  /* for PERROR */
 
   um = umask (777);
   umask (um);
-  if (stat (name, &sbuf) == -1)
+  fd = open(name, O_RDWR);
+  if (fd == -1)
+    {
+      PERROR (name);
+    }
+  if (fstat(fd, &sbuf) == -1)
     {
       PERROR (name);
     }
   sbuf.st_mode |= 0111 & ~um;
-  if (chmod (name, sbuf.st_mode) == -1)
-    PERROR (name);
+  if (fchmod(fd, sbuf.st_mode) == -1)
+    {
+      PERROR (name);
+    }
+  close(fd);
 }
 
 #ifdef COFF


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/75](https://github.com/cooljeanius/emacs/security/code-scanning/75)

To fix the TOCTOU race condition, we should use file descriptors instead of filenames for the operations. This ensures that the operations are performed on the same file, even if the file is changed between the operations. Specifically, we can use `fstat` and `fchmod` instead of `stat` and `chmod`.

1. Open the file using `open` to get a file descriptor.
2. Use `fstat` to get the file status.
3. Use `fchmod` to change the file permissions.
4. Close the file descriptor after the operations are complete.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
