### PR TITLE
Fix code scanning alert no. 39: Multiplication result converted to larger type

### DIFF
--- a/src/scroll.c
+++ b/src/scroll.c
@@ -800,7 +800,7 @@ scrolling_1 (struct frame *frame, int window_size, int unchanged_at_top,
 	     int *old_hash, int *new_hash, int free_at_end)
 {
   struct matrix_elt *matrix
-    = alloca ((window_size + 1) * (window_size + 1) * sizeof *matrix);
+    = alloca ((unsigned long)(window_size + 1) * (window_size + 1) * sizeof *matrix);
 
   if (FRAME_SCROLL_REGION_OK (frame))
     {

--- a/src/scroll.c
+++ b/src/scroll.c
@@ -793,14 +793,14 @@ do_direct_scrolling (struct frame *frame, struct glyph_matrix *current_matrix,
 }
 
 
-
+/* */
 void
 scrolling_1 (struct frame *frame, int window_size, int unchanged_at_top,
 	     int unchanged_at_bottom, int *draw_cost, int *old_draw_cost,
 	     int *old_hash, int *new_hash, int free_at_end)
 {
-  struct matrix_elt *matrix
-    = alloca ((unsigned long)(window_size + 1) * (window_size + 1) * sizeof *matrix);
+  struct matrix_elt *matrix =
+    (struct matrix_elt *)alloca((size_t)(window_size + 1UL) * (window_size + 1UL) * sizeof(*matrix));
 
   if (FRAME_SCROLL_REGION_OK (frame))
     {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/39](https://github.com/cooljeanius/emacs/security/code-scanning/39)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be done by casting one of the operands to `unsigned long` before performing the multiplication. This way, the multiplication will be done using `unsigned long` arithmetic, which has a larger range and can accommodate larger values without overflowing.

The specific change involves casting `window_size` to `unsigned long` before performing the multiplication on line 803. This ensures that the multiplication result is correctly calculated as an `unsigned long` before being passed to `alloca`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
