### PR TITLE
Fix code scanning alert no. 38: Multiplication result converted to larger type

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -2244,7 +2244,7 @@ x_create_x_image_and_pixmap(struct frame *f, int width, int height,
     }
 
   /* Allocate image raster: */
-  (*ximg)->data = xmalloc((*ximg)->bytes_per_line * height);
+  (*ximg)->data = xmalloc((size_t)(*ximg)->bytes_per_line * height);
 
   /* Allocate a pixmap of the same size: */
   *pixmap = XCreatePixmap(display, window, width, height, depth);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/38](https://github.com/cooljeanius/emacs/security/code-scanning/38)

To fix the problem, we need to ensure that the multiplication is performed using the larger `size_t` type to avoid overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the `size_t` type, which can hold larger values and prevent overflow.

The specific change involves casting `(*ximg)->bytes_per_line` to `size_t` before multiplying it by `height`. This change should be made on line 2247 of the file `src/image.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
