### PR TITLE
Fix code scanning alert no. 37: Multiplication result converted to larger type

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -3169,7 +3169,7 @@ xbm_image_p (Lisp_Object object)
       else if (STRINGP (data))
 	{
 	  if (SCHARS (data)
-	      < (width + BITS_PER_CHAR - 1) / BITS_PER_CHAR * height)
+	      < (width + BITS_PER_CHAR - 1) / BITS_PER_CHAR * (long) height)
 	    return 0;
 	}
       else if (BOOL_VECTOR_P (data))


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/37](https://github.com/cooljeanius/emacs/security/code-scanning/37)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be achieved by casting one of the operands to `long` before performing the multiplication. This way, the multiplication will be done in the `long` type, which has a larger range and can accommodate larger values without overflow.

Specifically, we will cast `height` to `long` before the multiplication. This change will be made on line 3172 of the file `src/image.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
