### PR TITLE
Fix code scanning alert no. 36: Multiplication result converted to larger type

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -3719,7 +3719,7 @@ xbm_load (struct frame *f, struct image *img)
 	      char *p;
 	      int nbytes = (img->width + BITS_PER_CHAR - 1) / BITS_PER_CHAR;
 
-	      p = bits = alloca ((unsigned long)nbytes * img->height);
+	      p = bits = (char *)alloca((size_t)nbytes * img->height);
 	      for (i = 0; i < img->height; ++i, p += nbytes)
 		{
 		  Lisp_Object line = AREF (data, i);

--- a/src/image.c
+++ b/src/image.c
@@ -3719,7 +3719,7 @@ xbm_load (struct frame *f, struct image *img)
 	      char *p;
 	      int nbytes = (img->width + BITS_PER_CHAR - 1) / BITS_PER_CHAR;
 
-	      p = bits = alloca (nbytes * img->height);
+	      p = bits = alloca ((unsigned long)nbytes * img->height);
 	      for (i = 0; i < img->height; ++i, p += nbytes)
 		{
 		  Lisp_Object line = AREF (data, i);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/36](https://github.com/cooljeanius/emacs/security/code-scanning/36)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (`unsigned long`) to prevent overflow. This can be done by casting one of the operands to `unsigned long` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly assigned to the `unsigned long` variable.

The specific change involves casting `nbytes` to `unsigned long` before the multiplication. This change should be made on line 3722 of `src/image.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
