### PR TITLE
Fix code scanning alert no. 35: Multiplication result converted to larger type

### DIFF
--- a/src/ccl.c
+++ b/src/ccl.c
@@ -2158,7 +2158,7 @@ usage: (ccl-execute-on-string CCL-PROGRAM STATUS STRING &optional CONTINUE UNIBY
 		      Qnil);
 	  produced_chars += ccl.produced;
 	  offset = outp - outbuf;
-	  shortfall = ccl.produced * max_expansion - (outbufsize - offset);
+	  shortfall = (ptrdiff_t)ccl.produced * max_expansion - (outbufsize - offset);
 	  if (shortfall > 0)
 	    {
 	      outbuf = xpalloc (outbuf, &outbufsize, shortfall, -1, 1);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/35](https://github.com/cooljeanius/emacs/security/code-scanning/35)

To fix the problem, we need to ensure that the multiplication is performed using the larger type to prevent overflow. This can be done by casting one of the operands to `ptrdiff_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correct.

The best way to fix this without changing existing functionality is to cast `ccl.produced` to `ptrdiff_t` before the multiplication. This change should be made on line 2161 of the file `src/ccl.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
