### PR TITLE
Fix code scanning alert no. 74: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/unexcoff.c
+++ b/src/unexcoff.c
@@ -439,16 +439,26 @@ mark_x (const char *name)
   struct stat sbuf;
   int um;
   int new = 0;  /* for PERROR */
+  int fd;
 
   um = umask (777);
   umask (um);
-  if (stat (name, &sbuf) == -1)
+  fd = open(name, O_WRONLY);
+  if (fd == -1)
     {
       PERROR (name);
+      return;
+    }
+  if (fstat(fd, &sbuf) == -1)
+    {
+      PERROR (name);
+      close(fd);
+      return;
     }
   sbuf.st_mode |= 0111 & ~um;
-  if (chmod (name, sbuf.st_mode) == -1)
+  if (fchmod(fd, sbuf.st_mode) == -1)
     PERROR (name);
+  close(fd);
 }
 
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/emacs/security/code-scanning/74](https://github.com/cooljeanius/emacs/security/code-scanning/74)

To fix the TOCTOU race condition, we should use file descriptors instead of file names for the `chmod` operation. This can be achieved by opening the file and then using `fchmod` on the file descriptor. This ensures that the file being operated on is the same file that was checked.

1. Open the file using `open` to get a file descriptor.
2. Use `fstat` on the file descriptor to get the file status.
3. Use `fchmod` on the file descriptor to change the file permissions.
4. Close the file descriptor after the operations are complete.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
